### PR TITLE
Bump CLI version to 2.9.1

### DIFF
--- a/Casks/1password-cli.rb
+++ b/Casks/1password-cli.rb
@@ -1,6 +1,6 @@
 cask "1password-cli" do
-  version "2.7.2"
-  sha256 "a4bdfd57d00ed838c271695e72d79330270105955bdd15e627cc24e60c85a238"
+  version "2.9.0"
+  sha256 "daa5be07739de5c5e3f4b91f98e008c0be8863aa008864db6f0255be5529f292"
 
   url "https://cache.agilebits.com/dist/1P/op2/pkg/v#{version}/op_apple_universal_v#{version}.pkg"
   name "1Password CLI"

--- a/Casks/1password-cli.rb
+++ b/Casks/1password-cli.rb
@@ -1,6 +1,6 @@
 cask "1password-cli" do
-  version "2.9.0"
-  sha256 "daa5be07739de5c5e3f4b91f98e008c0be8863aa008864db6f0255be5529f292"
+  version "2.9.1"
+  sha256 "20568b70c5ce2dcd2864859539a0eec94994c4973e29e7a0efb451fd29421b12"
 
   url "https://cache.agilebits.com/dist/1P/op2/pkg/v#{version}/op_apple_universal_v#{version}.pkg"
   name "1Password CLI"


### PR DESCRIPTION
Updating the CLI version to 2.9.1.

**DON'T MERGE BEFORE WEDNESDAY, DECEMBER 7TH**

Please note: despite the branch name, we'll update to the 2.9.1, which will be released at the same time with 2.9.0 but will contain a patch fix on top of it.